### PR TITLE
Change `user_name` + `User name` to `username` + `Username`

### DIFF
--- a/configurator
+++ b/configurator
@@ -92,12 +92,12 @@ user_form() {
   step "Let's setup your machine..."
 
   while true; do
-    username=$(gum input --placeholder "Alphanumeric without spaces (like dhh)" --prompt.foreground="#845DF9" --prompt "User name> ") || abort
+    username=$(gum input --placeholder "Alphanumeric without spaces (like dhh)" --prompt.foreground="#845DF9" --prompt "Username> ") || abort
 
     if [[ "$username" =~ ^[a-z_][a-z0-9_-]*[$]?$ ]]; then
       break
     else
-      notice "User name must be alphanumeric with no spaces" 1
+      notice "Username must be alphanumeric with no spaces" 1
     fi
   done
 
@@ -150,7 +150,7 @@ user_form
 
 while true; do
   echo -e "Field,Value
-User name,$username
+Username,$username
 Password,$(printf "%${#password}s" | tr ' ' '*')
 Full name,${full_name:-[Skipped]}
 Email address,${email_address:-[Skipped]}

--- a/configurator
+++ b/configurator
@@ -92,9 +92,9 @@ user_form() {
   step "Let's setup your machine..."
 
   while true; do
-    user_name=$(gum input --placeholder "Alphanumeric without spaces (like dhh)" --prompt.foreground="#845DF9" --prompt "User name> ") || abort
+    username=$(gum input --placeholder "Alphanumeric without spaces (like dhh)" --prompt.foreground="#845DF9" --prompt "User name> ") || abort
 
-    if [[ "$user_name" =~ ^[a-z_][a-z0-9_-]*[$]?$ ]]; then
+    if [[ "$username" =~ ^[a-z_][a-z0-9_-]*[$]?$ ]]; then
       break
     else
       notice "User name must be alphanumeric with no spaces" 1
@@ -150,7 +150,7 @@ user_form
 
 while true; do
   echo -e "Field,Value
-User name,$user_name
+User name,$username
 Password,$(printf "%${#password}s" | tr ' ' '*')
 Full name,${full_name:-[Skipped]}
 Email address,${email_address:-[Skipped]}
@@ -242,7 +242,7 @@ cat <<-_EOF_ | tee user_credentials.json >/dev/null
             "enc_password": "$password_hash",
             "groups": [],
             "sudo": true,
-            "username": "$user_name"
+            "username": "$username"
         }
     ]
 }


### PR DESCRIPTION
In the setup script, users could get confused by **User name** being their full name, as in the user's name.

This PR changes that to **Username** instead, which seems to be most widely used. See sources below.
I also updated the variable name, but this could be reverted if used elsewhere as `$user_name`.

Looking forward to trying out Omarchy myself later next month 🎉

---

> The first prompt of "User name>" should be "Username>", as is typical; could be confused, as I did, for the user's name.
> 
> Source: https://discord.com/channels/1390012484194275541/1408072415690621019/1409621022818177056

---

> The username is the (usually unique) thing you type in with your password, for example: bobsmith66.
> 
> The user name is the name of the user, the user's real life name, for example: Bob Smith. User name is sometimes used for username, but occasionally it makes a difference, so be clear and avoid the ambiguity. (Better still, use full name when you want them to enter Bob Smith.)
> 
> Source: https://english.stackexchange.com/a/43470