### PR TITLE
Use JQ to escape credentials for user credentials json

### DIFF
--- a/configurator
+++ b/configurator
@@ -239,14 +239,14 @@ username_escaped=$(echo -n "$username" | jq -Rsa)
 
 cat <<-_EOF_ | tee user_credentials.json >/dev/null
 {
-    "encryption_password": "$password_escaped",
-    "root_enc_password": "$password_hash_escaped",
+    "encryption_password": $password_escaped,
+    "root_enc_password": $password_hash_escaped,
     "users": [
         {
-            "enc_password": "$password_hash_escaped",
+            "enc_password": $password_hash_escaped,
             "groups": [],
             "sudo": true,
-            "username": "$username_escaped"
+            "username": $username_escaped
         }
     ]
 }

--- a/configurator
+++ b/configurator
@@ -233,16 +233,20 @@ boot_partition_size=$((2 * gib))
 main_partition_start=$((boot_partition_size + boot_partition_start))
 main_partition_size=$((disk_size_in_mib - main_partition_start - gpt_backup_reserve))
 
+password_escaped=$(echo -n "$password" | jq -Rsa)
+password_hash_escaped=$(echo -n "$password_hash" | jq -Rsa)
+username_escaped=$(echo -n "$username" | jq -Rsa)
+
 cat <<-_EOF_ | tee user_credentials.json >/dev/null
 {
-    "encryption_password": "$password",
-    "root_enc_password": "$password_hash",
+    "encryption_password": "$password_escaped",
+    "root_enc_password": "$password_hash_escaped",
     "users": [
         {
-            "enc_password": "$password_hash",
+            "enc_password": "$password_hash_escaped",
             "groups": [],
             "sudo": true,
-            "username": "$username"
+            "username": "$username_escaped"
         }
     ]
 }

--- a/configurator
+++ b/configurator
@@ -326,7 +326,7 @@ cat <<-_EOF_ | tee user_configuration.json >/dev/null
             "encryption_type": "luks",
             "lvm_volumes": [],
             "partitions": [ "8c2c2b92-1070-455d-b76a-56263bab24aa" ],
-            "encryption_password": "$password"
+            "encryption_password": $password_escaped
         }
     },
     "hostname": "$hostname",


### PR DESCRIPTION
Characters like '\\' being in the password currently break jq in the iso installer because they are not valid JSON. 

I have escaped the values going into user_credentials.json. When they pulled out by jq again they should be unescaped automatically.

I don't write much bash, so it might not be very idiomatic. No hard feelings if it is rejected