### PR TITLE
Add Unified Kernel Image

### DIFF
--- a/configurator
+++ b/configurator
@@ -326,7 +326,12 @@ cat <<-_EOF_ | tee user_configuration.json >/dev/null
         }
     },
     "hostname": "$hostname",
-    "kernels": [ "linux" ],
+    "kernels": [
+      {
+        "name": "linux",
+        "unified": true
+      }
+    ],
     "network_config": { "type": "iso" },
     "ntp": true,
     "parallel_downloads": 8,


### PR DESCRIPTION
THIS NEEDS REVIEW. REFER TO THE NOTE AT THE BOTTOM.

Add Unified Kernel Image option option during omarchy install.

3.1 in the below link describes how to add to Limine bootloader.

https://wiki.archlinux.org/title/Unified_kernel_image

limine.conf
/Arch Linux
  protocol: efi
  path: boot():/EFI/Linux/arch-linux.efi

Note: I'm not 100% sure this is the correct syntax. This was recommended by ChatGPT.
I couldn't find the correct syntax on the archinstall wiki. I also tried applying UKI on a live archinstall to check the output config file but it did not show any changes.