### PR TITLE
Add 'snapshots' Subvolume

### DIFF
--- a/configurator
+++ b/configurator
@@ -293,7 +293,8 @@ cat <<-_EOF_ | tee user_configuration.json >/dev/null
                             { "mountpoint": "/", "name": "@" },
                             { "mountpoint": "/home", "name": "@home" },
                             { "mountpoint": "/var/log", "name": "@log" },
-                            { "mountpoint": "/var/cache/pacman/pkg", "name": "@pkg" }
+                            { "mountpoint": "/var/cache/pacman/pkg", "name": "@pkg" },
+                            { "mountpoint": "/.snapshots", "name": "@snapshots" }
                         ],
                         "dev_path": null,
                         "flags": [],


### PR DESCRIPTION
Add '@snapshots' sub-volume mounted on '/.snapshots' as recommended in 5.4 on 'Snapper" Arch wiki page.

https://wiki.archlinux.org/title/Snapper

