### PR TITLE
First ask for keyboard layout

### DIFF
--- a/configurator
+++ b/configurator
@@ -47,7 +47,25 @@ notice() {
   gum spin --spinner "globe" --title "$1" -- sleep "${2:-2}"
 }
 
-# STEP 1: NETWORK (OPTIONAL WHEN RUNNING OFFLINE INSTALLATION)
+# STEP 1: KEYBOARD LAYOUT
+
+step "Select your keyboard layout..."
+keyboards=$'Albanian|al\nAmharic|et\nArmenian|am\nArabic|ara\nArabic (Egypt)|eg\nArabic (Iraq)|iq\nArabic (Morocco)|ma\nArabic (Syria)|sy\nAzerbaijani|az\nBambara|ml\nBangla|bd\nBelarusian|by\nBelgian|be\nBerber (Algeria, Latin)|dz\nBosnian|ba\nBraille|brai\nBulgarian|bg\nBurmese|mm\nChinese|cn\nCroatian|hr\nCzech|cz\nDanish|dk\nDari|af\nDhivehi|mv\nDutch|nl\nDzongkha|bt\nEnglish (Australia)|au\nEnglish (Cameroon)|cm\nEnglish (Ghana)|gh\nEnglish (New Zealand)|nz\nEnglish (Nigeria)|ng\nEnglish (South Africa)|za\nEnglish (UK)|uk\nEnglish (US)|us\nEsperanto|epo\nEstonian|ee\nFaroese|fo\nFilipino|ph\nFinnish|fi\nFrench|fr\nFrench (Canada)|ca\nFrench (Democratic Republic of the Congo)|cd\nFrench (Togo)|tg\nGeorgian|ge\nGerman|de\nGerman (Austria)|at\nGerman (Switzerland)|ch\nGreek|gr\nHebrew|il\nHungarian|hu\nIcelandic|is\nIndian|in\nIndonesian (Latin)|id\nIrish|ie\nItalian|it\nJapanese|jp\nKazakh|kz\nKhmer (Cambodia)|kh\nKorean|kr\nKyrgyz|kg\nLao|la\nLatvian|lv\nLithuanian|lt\nMacedonian|mk\nMalay (Jawi, Arabic Keyboard)|my\nMaltese|mt\nMoldavian|md\nMongolian|mn\nMontenegrin|me\nNepali|np\nNKo (AZERTY)|gn\nNorwegian|no\nPersian|ir\nPolish|pl\nPortuguese|pt\nPortuguese (Brazil)|br\nRomanian|ro\nRussian|ru\nSerbian|rs\nSinhala (phonetic)|lk\nSlovak|sk\nSlovenian|si\nSpanish|es\nSpanish (Latin American)|latam\nSwahili (Kenya)|ke\nSwahili (Tanzania)|tz\nSwedish|se\nTaiwanese|tw\nTajik|tj\nThai|th\nTswana|bw\nTurkmen|tm\nTurkish|tr\nUkrainian|ua\nUrdu (Pakistan)|pk\nUzbek|uz\nVietnamese|vn\nWolof|sn'
+keyboard=$(
+  choice=$(printf '%s\n' "$keyboards" | cut -d'|' -f1 |
+    gum choose --height 10 --selected "English (US)" --header "Keyboard layout") || abort
+  printf '%s\n' "$keyboards" | awk -F'|' -v c="$choice" '$1==c{print $2; exit}'
+)
+
+# Apply keyboard layout immediately
+step "Applying keyboard layout $keyboard..."
+if loadkeys "$keyboard" 2>/dev/null; then
+  notice "Keyboard layout applied successfully" 1
+else
+  notice "Could not apply keyboard layout, continuing anyway" 1
+fi
+
+# STEP 2: NETWORK (OPTIONAL WHEN RUNNING OFFLINE INSTALLATION)
 
 if [[ -z $NETWORK_NOT_NEEDED ]]; then
   step "Detecting network..."
@@ -86,7 +104,7 @@ if [[ -z $NETWORK_NOT_NEEDED ]]; then
   fi
 fi
 
-# STEP 2: USER
+# STEP 3: USER
 
 user_form() {
   step "Let's setup your machine..."
@@ -136,14 +154,6 @@ user_form() {
   else
     timezone=$(timedatectl list-timezones | gum filter --height 10 --header "Timezone") || abort
   fi
-
-  # Pick keyboard layout
-  keyboards=$'Albanian|al\nAmharic|et\nArmenian|am\nArabic|ara\nArabic (Egypt)|eg\nArabic (Iraq)|iq\nArabic (Morocco)|ma\nArabic (Syria)|sy\nAzerbaijani|az\nBambara|ml\nBangla|bd\nBelarusian|by\nBelgian|be\nBerber (Algeria, Latin)|dz\nBosnian|ba\nBraille|brai\nBulgarian|bg\nBurmese|mm\nChinese|cn\nCroatian|hr\nCzech|cz\nDanish|dk\nDari|af\nDhivehi|mv\nDutch|nl\nDzongkha|bt\nEnglish (Australia)|au\nEnglish (Cameroon)|cm\nEnglish (Ghana)|gh\nEnglish (New Zealand)|nz\nEnglish (Nigeria)|ng\nEnglish (South Africa)|za\nEnglish (UK)|uk\nEnglish (US)|us\nEsperanto|epo\nEstonian|ee\nFaroese|fo\nFilipino|ph\nFinnish|fi\nFrench|fr\nFrench (Canada)|ca\nFrench (Democratic Republic of the Congo)|cd\nFrench (Togo)|tg\nGeorgian|ge\nGerman|de\nGerman (Austria)|at\nGerman (Switzerland)|ch\nGreek|gr\nHebrew|il\nHungarian|hu\nIcelandic|is\nIndian|in\nIndonesian (Latin)|id\nIrish|ie\nItalian|it\nJapanese|jp\nKazakh|kz\nKhmer (Cambodia)|kh\nKorean|kr\nKyrgyz|kg\nLao|la\nLatvian|lv\nLithuanian|lt\nMacedonian|mk\nMalay (Jawi, Arabic Keyboard)|my\nMaltese|mt\nMoldavian|md\nMongolian|mn\nMontenegrin|me\nNepali|np\nNKo (AZERTY)|gn\nNorwegian|no\nPersian|ir\nPolish|pl\nPortuguese|pt\nPortuguese (Brazil)|br\nRomanian|ro\nRussian|ru\nSerbian|rs\nSinhala (phonetic)|lk\nSlovak|sk\nSlovenian|si\nSpanish|es\nSpanish (Latin American)|latam\nSwahili (Kenya)|ke\nSwahili (Tanzania)|tz\nSwedish|se\nTaiwanese|tw\nTajik|tj\nThai|th\nTswana|bw\nTurkmen|tm\nTurkish|tr\nUkrainian|ua\nUrdu (Pakistan)|pk\nUzbek|uz\nVietnamese|vn\nWolof|sn'
-  keyboard=$(
-    choice=$(printf '%s\n' "$keyboards" | cut -d'|' -f1 |
-      gum choose --height 10 --selected "English (US)" --header "Keyboard layout") || abort
-    printf '%s\n' "$keyboards" | awk -F'|' -v c="$choice" '$1==c{print $2; exit}'
-  )
 }
 
 user_form
@@ -167,7 +177,7 @@ Keyboard,$keyboard" |
   fi
 done
 
-# STEP 3: DISK
+# STEP 4: DISK
 
 get_disk_info() {
   local device="$1"


### PR DESCRIPTION
See #9. Better to type wifi and session password in chosen locale.

Tested with 

```
OMARCHY_CONFIGURATOR_REPO="bastnic/omarchy-configurator" OMARCHY_CONFIGURATOR_REF="gh-9" ./bin/omarchy-iso-make
```

and now the locale is the first step and the layout is well applied

<img width="856" height="1004" alt="image" src="https://github.com/user-attachments/assets/ab8b7613-6b45-415b-8b18-bbda9876140c" />
