### PR TITLE
Self-update

### DIFF
--- a/configurator
+++ b/configurator
@@ -12,8 +12,8 @@ OMARCHY_LOGO='                 ▄▄▄
                                        ███   █▀                                  '
 
 # Install prerequisites
-if ! command -v gum >/dev/null || ! command -v iwctl >/dev/null; then
-  sudo pacman -Sy --noconfirm --needed gum iw
+if ! command -v gum >/dev/null || ! command -v iwctl >/dev/null || ! command -v curl >/dev/null; then
+  sudo pacman -Sy --noconfirm --needed gum iw curl
 fi
 
 if ! command -v tzupdate >/dev/null; then
@@ -45,6 +45,56 @@ step() {
 notice() {
   clear_logo
   gum spin --spinner "globe" --title "$1" -- sleep "${2:-2}"
+}
+
+check_for_updates() {
+  step "Checking for updates..."
+
+  local dest
+  dest="$(readlink -f "$0" 2>/dev/null || realpath "$0" 2>/dev/null || printf '%s' "$0")"
+  local dest_dir
+  dest_dir="$(dirname "$dest")"
+
+  local tmp
+  tmp="$(mktemp "$dest_dir/.configurator.XXXXXX")" || return 0
+  trap 'rm -f "$tmp" 2>/dev/null || true' RETURN
+
+  OMARCHY_CONFIGURATOR_REMOTE_URL="${OMARCHY_CONFIGURATOR_REMOTE_URL:-https://raw.githubusercontent.com/omacom-io/omarchy-configurator/refs/heads/master/configurator}"
+
+  if ! curl -fsSLo "$tmp" --connect-timeout 5 -m 20 "$OMARCHY_CONFIGURATOR_REMOTE_URL"; then
+    notice "Could not check for updates, continuing..." 1
+    return 1
+  fi
+
+  if ! head -n1 "$tmp" | grep -q '^#!'; then
+    notice "Update rejected (invalid content)" 1
+    return 1
+  fi
+
+  if [ ! -s "$tmp" ]; then
+    notice "Update rejected (empty file)" 1
+    return 1
+  fi
+
+  if cmp -s "$tmp" "$dest"; then
+    notice "Already using the latest version" 1
+    return 0
+  fi
+
+  notice "New version found, updating..." 2
+  if ! chmod 0755 "$tmp"; then
+    notice "Failed to set permissions on new version" 1
+    return 1
+  fi
+
+  # Remplacement atomique
+  if mv -f "$tmp" "$dest"; then
+    trap - RETURN
+    export NO_UPDATE_CHECK=1
+    exec "$dest" "$@"
+  else
+    notice "Update failed (no write perms?)" 1
+  fi
 }
 
 # STEP 1: KEYBOARD LAYOUT
@@ -95,6 +145,10 @@ if [[ -z $NETWORK_NOT_NEEDED ]]; then
     else
       abort "Couldn't find any Wi-Fi networks. Try manually configuring Wi-Fi with: iwctl"
     fi
+  fi
+
+  if [[ -z $NO_UPDATE_CHECK ]] && working_network 1; then
+    check_for_updates "$@"
   fi
 fi
 
@@ -167,7 +221,6 @@ Keyboard,$keyboard" |
   if gum confirm --negative "No, change it" "Does this look right?"; then
     break
   else
-    keyboard_form
     user_form
   fi
 done


### PR DESCRIPTION
Attempt to fix #8, and think to potential issues:
- master is considered as stable, as omarchy does
- only call if we have network, but it will ask again for wifi setting the second time. Of course, if the configutor is updated to fix something in the phase of acquiring a network connection, it will not be fetched
- added some security to curl call, we are on a sensible path. Maybe add retry instead?
- seems nice to add the possibility to change the configurator url at runtime but we are supposed to be in an ISO, not sure it makes sens
- checksum is a good practice, but maybe too much?
