### PR TITLE
Fix: potential partial upgrade

### DIFF
--- a/configurator
+++ b/configurator
@@ -13,11 +13,11 @@ OMARCHY_LOGO='                 ▄▄▄
 
 # Install prerequisites
 if ! command -v gum >/dev/null || ! command -v iwctl >/dev/null; then
-  sudo pacman -Sy --noconfirm --needed gum iw
+  sudo pacman -Syu --noconfirm --needed gum iw
 fi
 
 if ! command -v tzupdate >/dev/null; then
-  yay -Sy --noconfirm tzupdate
+  yay -Syu --noconfirm tzupdate
 fi
 
 abort() {


### PR DESCRIPTION
`pacman -Sy` can lead to partial upgrades, which are [unsupported on Arch Linux](https://wiki.archlinux.org/title/System_maintenance#Partial_upgrades_are_unsupported).

Replaced it with `pacman -Syu` to ensure the package database and system are in sync before installing, following Arch best practices.