### PR TITLE
Allow special characters in SSID

### DIFF
--- a/configurator
+++ b/configurator
@@ -86,7 +86,7 @@ if [[ -z $NETWORK_NOT_NEEDED ]]; then
         ssid="$(echo "$networks" | gum choose --header "Select Wi-Fi network")" || abort
 
         step "Connecting to $ssid..."
-        if iwctl station "$wifi_interface" connect "$ssid" && working_network 5; then
+        if iwctl station "$wifi_interface" connect "$(echo -e "$ssid")" && working_network 5; then
           break
         else
           notice "Couldn't connect to network (bad password?)" 1


### PR DESCRIPTION
This PR allows connecting to wifi SSIDs containing special characters (and emoji).

The output of `iw dev ... scan` for the SSID 🇩🇰 is `\xf0\x9f\x87\xa9\xf0\x9f\x87\xb0`. However `iwctl station ... connect` requires those backslash escapes to have been interpreted.

Should also fix connecting to default iPhone hotspots with a curly apostrophe like *Zach’s iPhone*.