### PR TITLE
Fix support /dev/xv* drives

### DIFF
--- a/configurator
+++ b/configurator
@@ -204,7 +204,7 @@ disk_form() {
       disk_info=$(get_disk_info "$device")
       disk_options="$disk_options$disk_info"$'\n'
     fi
-  done < <(lsblk -dpno NAME,TYPE | grep -E '/dev/(sd|hd|vd|nvme|mmcblk)' | awk '{print $1}')
+  done < <(lsblk -dpno NAME,TYPE | grep -E '/dev/(sd|hd|vd|nvme|mmcblk|xv)' | awk '{print $1}')
 
   selected_display=$(echo "$disk_options" | gum choose --header "Select install disk") || abort
   disk=$(echo "$selected_display" | awk '{print $1}')


### PR DESCRIPTION
Some configurations using the [Xen](https://xenproject.org/) hypervisor mount their disks under `/dev/xd*` rather than the more traditional /dev/sda or whatnot.



Thanks for making it so easy to workaround by the way, love how the command the terminal executes is echoed on failure, makes it really easy to debug and work around issues.